### PR TITLE
A few extensions that might be of interest

### DIFF
--- a/plantgw.yaml
+++ b/plantgw.yaml
@@ -8,9 +8,13 @@ mqtt:
 
     #prefix of the topic where the sensor data will be published, mandatory
     prefix: some/prefix/my/plants
+    #terminate topic with a trailing slash, optional as defaults to True
+    #trailing_slash: False
 
     #port of the mqtt server, optional if using 8883
     #port: 8883
+    #client_id to use with the mqtt server, optional as defaults to unique numeric identifier
+    #client_id: PlantGateway
 
     #credentials for the mqtt server, optional if you do not use authentication
     #user:
@@ -18,6 +22,9 @@ mqtt:
 
     #path to ssl/tls ca file
     #ca_cert: /etc/ssl/certs/<my ca file.pem>
+
+    #format for timestamp string using strftime(), optional as defaults to ISO8601 format
+    #timestamp_format: "%d/%m/%y %H:%M:%S"
 
 # sensor configuration, replace this with the configuration of your sensors
 sensors:

--- a/plantgw/__init__.py
+++ b/plantgw/__init__.py
@@ -43,6 +43,9 @@ class Configuration(object):
         self.mqtt_user = None
         self.mqtt_password = None
         self.mqtt_ca_cert = None
+        self.mqtt_client_id = None
+        self.mqtt_trailing_slash = True
+        self.mqtt_timestamp_format = None
         self.sensors = []
 
         if 'port' in config['mqtt']:
@@ -56,6 +59,15 @@ class Configuration(object):
 
         if 'ca_cert' in config['mqtt']:
             self.mqtt_ca_cert = config['mqtt']['ca_cert']
+
+        if 'client_id' in config['mqtt']:
+            self.mqtt_client_id = config['mqtt']['client_id']
+
+        if 'trailing_slash' in config['mqtt'] and not config['mqtt']['trailing_slash']:
+            self.mqtt_trailing_slash = False
+
+        if 'timestamp_format' in config['mqtt']:
+            self.mqtt_timestamp_format = config['mqtt']['timestamp_format']
 
         self.mqtt_server = config['mqtt']['server']
         self.mqtt_prefix = config['mqtt']['prefix']
@@ -113,7 +125,7 @@ class PlantGateway(object):
         logging.info('Disconnected MQTT connection')
 
     def _start_client(self):
-        self.mqtt_client = mqtt.Client()
+        self.mqtt_client = mqtt.Client(self.config.mqtt_client_id)
         if self.config.mqtt_user is not None:
             self.mqtt_client.username_pw_set(self.config.mqtt_user, self.config.mqtt_password)
         if self.config.mqtt_ca_cert is not None:
@@ -130,7 +142,12 @@ class PlantGateway(object):
     def _publish(self, sensor_config, sensor_data):
         if not self.connected:
             raise Exception('not connected to MQTT server')
-        prefix = '{}/{}/'.format(self.config.mqtt_prefix, sensor_config.get_topic())
+
+        prefix_fmt = '{}/{}'
+        if self.config.mqtt_trailing_slash:
+            prefix_fmt += '/'
+        prefix = prefix_fmt.format(self.config.mqtt_prefix, sensor_config.get_topic())
+
         data = {
             'battery': sensor_data.battery,
             'temperature': '{0:.1f}'.format(sensor_data.temperature),
@@ -139,6 +156,8 @@ class PlantGateway(object):
             'conductivity': sensor_data.conductivity,
             'timestamp': datetime.now().isoformat(),
         }
+        if self.config.mqtt_timestamp_format is not None:
+            data['timestamp'] = datetime.now().strftime(self.config.mqtt_timestamp_format)
         json_payload = json.dumps(data)
         self.mqtt_client.publish(prefix, json_payload, qos=1, retain=True)
         logging.info('sent data to topic %s', prefix)
@@ -172,7 +191,7 @@ class PlantGateway(object):
                 try:
                     self.process_mac(sensor)
                 # pylint: disable=bare-except
-                 except Exception as e:
+                except Exception as e:
                     next_list.append(sensor) # if it failed, we'll try again in the next round
                     msg = "could not read data from {} ({}) with reason: {}".format(sensor.mac, sensor.alias, str(e))
                     if sensor.fail_silent:

--- a/plantgw/__init__.py
+++ b/plantgw/__init__.py
@@ -172,13 +172,14 @@ class PlantGateway(object):
                 try:
                     self.process_mac(sensor)
                 # pylint: disable=bare-except
-                except:
+                 except Exception as e:
                     next_list.append(sensor) # if it failed, we'll try again in the next round
-                    msg = "could not read data from {} ({})".format(sensor.mac, sensor.alias)
-                    logging.exception(msg)
+                    msg = "could not read data from {} ({}) with reason: {}".format(sensor.mac, sensor.alias, str(e))
                     if sensor.fail_silent:
+                        logging.error(msg)
                         logging.warning('fail_silent is set for sensor %s, so not raising an exception.', sensor.alias)
                     else:
+                        logging.exception(msg)
                         print(msg)
 
         # return sensors that could not be processed after max_retry

--- a/plantgw/__init__.py
+++ b/plantgw/__init__.py
@@ -92,13 +92,25 @@ class SensorConfig(object):
 class PlantGateway(object):
     """Main class of the module."""
 
-    def __init__(self, config_file_path='~/.plantgw.yaml'):
+    def __init__(self, config_file_path='~/.plantgw.yaml', start_client = True):
         config_file_path = os.path.abspath(os.path.expanduser(config_file_path))
         self.config = Configuration(config_file_path)
         logging.info('loaded config file from %s', config_file_path)
         self.mqtt_client = None
         self.connected = False
-        self._start_client()
+        if start_client:
+            self._start_client()
+
+    def start_client(self):
+        if not self.connected:
+            self._start_client()
+
+    def stop_client(self):
+        if self.connected:
+            self.mqtt_client.disconnect()
+            self.connected = False
+        self.mqtt_client.loop_stop()
+        logging.info('Disconnected MQTT connection')
 
     def _start_client(self):
         self.mqtt_client = mqtt.Client()

--- a/plantgw/plantgateway
+++ b/plantgw/plantgateway
@@ -27,6 +27,7 @@ def main():
             print('Could not get data from {}sensor(s): {}.'.format(
                 len(failed_sensors),
                 SensorConfig.get_name_string(failed_sensors)))
+        pg.stop_client()
         sys.exit(len(failed_sensors))
 
 


### PR DESCRIPTION
Christian,

First off, thanks for a great component that is now feeding my Home Assistant with data from 15 remote Mi Floras!!!

While setting things up, I made a few tweaks that helped align this with the rest of my setup. I have submitted these tweaks in three commits so you can pick and choose if you think they may be useful to others.

1) 1a6c580 - The default plantgateway behaviour is to establish the mqtt connection but to implicitly disconnect via timing out after exit. While this is fine functionally, unfortunately Mosquitto complains of a socket error when it doesn't get an explicit disconnect. So to keep the broker happy, I added an explicit mqtt disconnect before exiting.

2) 7439a7c - My Mi Floras don't have perfect signal and I quite often get retries. I have enabled fail_silent but noticed that the plantgw.log still gets filled with exception traces making quick scanning of the log difficult. For me it was more intuitive to suppress exception trace logging when fail_silent was set.

3) cc48fb0 - I ended up adding a few config options in plantgw.yaml to adjust the interface:
        - client_id: let me set a recognisable name for the client when displayed by the mqtt broker
        - trailing_slashes: let me have topic names that didn't end with a "/"
        - timestamp_format: let me configure locale specific timestamp strings to display

As I say, none of these are really significant but rather a few tweaks that you/others may find useful and thanks again for the platform.