### PR TITLE
Force PyYAML Version to 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 bluepy==1.1.4
 paho-mqtt
-pyyaml
+pyyaml==3.13
 miflora==0.4


### PR DESCRIPTION
Version 4.1 has been removed from PiWheels, and breaks the installation of plantgateway.

This changes the version requirement for this library to 3.13, which is still available on PiWheels, and allows plantgateway to install.

Fixes #22